### PR TITLE
feat(ask): 共感強め・短文のbuddy返信を既定化し自動トーン/長さ/追い問い調整を実装

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,47 @@
+import os, sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+def make_client(tmpdir: Path):
+    os.environ["DATABASE_URL"] = f"sqlite:///{tmpdir}/nolook_test.db"
+    os.environ["NOLOOK_DISABLE_OPENAI"] = "1"
+    os.environ["NOLOOK_RATE_LIMIT_PER_MIN"] = "0"
+    os.environ["ALLOWED_ORIGINS"] = "http://localhost:3000"
+    if "genai.main" in sys.modules:
+        del sys.modules["genai.main"]
+    import genai.main as main
+    main.API_KEY = None
+    client = TestClient(main.app)
+    return main, client
+
+def test_ask_sad(tmp_path):
+    m, client = make_client(tmp_path)
+    r = client.post("/ask", json={"prompt": "今日は萎えたー"})
+    assert r.status_code == 200
+    js = r.json()
+    assert js["emotion"] == "悲しい"
+    assert list(js["labels"].keys()) == m.EMOTION_KEYS
+
+def test_ask_anger(tmp_path):
+    m, client = make_client(tmp_path)
+    r = client.post("/ask", json={"prompt": "俺のミスじゃないのに責められてイライラする"})
+    assert r.status_code == 200
+    assert r.json()["emotion"] == "怒り"
+
+def test_long_input_ok(tmp_path):
+    m, client = make_client(tmp_path)
+    long_text = "あ" * 5000
+    r = client.post("/ask", json={"prompt": long_text})
+    assert r.status_code == 200
+
+def test_analyze_and_summary(tmp_path):
+    m, client = make_client(tmp_path)
+    client.post("/analyze", json={"prompt": "部活で最悪…落ち込んだ"})
+    client.post("/analyze", json={"prompt": "部活でムカついた"})
+    r = client.get("/summary", params={"days": 1, "tz": "Asia/Tokyo"})
+    assert r.status_code == 200
+    js = r.json()
+    assert js["days"] == 1
+    day = js["daily"][0]["counts"]
+    assert day["悲しい"] >= 1
+    assert day["怒り"] >= 1


### PR DESCRIPTION
feat(report): /weekly_report を追加（週次集計・簡易サマリ）
fix(summary): タイムゾーン/UTC変換を安定化
feat(emotion): スラング '萎え' を悲しいにマッピング
chore(api): API Key/RateLimit/CORS allowlist・統一エラーハンドラ・Request-ID

### 変更点
- ask: ユーザーはテキスト1行だけでOK。サーバ側で style/length/followup を自動調整
  - 喜び→buddy称賛（短文）
  - 悲しい/不安→buddy寄り添い（必要時のみ2文）
  - 怒り→coach（鎮静＋安全な一手）
  - しんどい→休息寄り buddy
  - 危険語は問い控えめ＆安全案内を優先
- emotion: スラング「萎え*」を悲しいに寄せる辞書拡充
- report: `/weekly_report` 追加（直近 n 日の集計 + trend + サマリ/提案）
- summary: 生成時刻を UTC naive とみなし tz 集計を安定化
- security: X-API-Key / 1分あたりRateLimit / CORS allowlist
- DX: 統一 422/500 エラーハンドラ + X-Request-ID ログ

### 動作確認
- `pytest -q` → all passed
- Swagger で `/ask` `/analyze` `/summary` `/weekly_report` を手動確認
- OpenAI 無効でも動作（`NOLOOK_DISABLE_OPENAI=1`）

### 互換性
- 既存クライアントは `prompt` だけ送ればOK（追加パラメータは不要）
